### PR TITLE
FIX TYPO IN 'Assignment' SECTION OF README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Now we start on the other side of the fence, where you have no tests, only worki
 - open the `basic-javascript` folder and use `project-1.spec.js` to write tests for the functions inside `project-1.js`.
 - use `project-2.spec.js` to write tests for the functions inside `project-2.js`.
 
-As you write your tests, bugs in the code may be revealed, feel free to correct and _refactor_ the source code to sitisfy your tests.
+As you write your tests, bugs in the code may be revealed, feel free to correct and _refactor_ the source code to satisfy your tests.
 
 ## Stretch Goal
 


### PR DESCRIPTION
Previously the last sentence in the `Assignment` section said `feel free to correct and refactor the source code to **sitisfy** your tests.` and now reads as **satisfy**